### PR TITLE
refactor: Use folder_paths for output and temp directories in VeoVideoSaveAndPreview

### DIFF
--- a/google_genmedia/helper_nodes.py
+++ b/google_genmedia/helper_nodes.py
@@ -235,16 +235,14 @@ class VeoVideoSaveAndPreview:
                         shutil.copy2(video_path_abs, dest_path)
                         logger.info(f"Video copied to: {dest_path}")
                         video_subfolder = "veo"
+                        filename_for_ui = dest_name
                     else:
-                        # if it is just for preview, strip the filename and build the path starting temp directory
-                        dest_path = os.path.join(
-                            os.path.normpath("temp"),
-                            os.path.normpath(video_path_abs)
-                            .rsplit(os.path.normpath("temp"), 1)[1]
-                            .lstrip(os.path.sep),
-                        )
+                        # if it is just for preview, get path relative to temp directory
+                        temp_dir = folder_paths.get_temp_directory()
+                        filename_for_ui = os.path.normpath(video_path_abs).rsplit(os.path.normpath(temp_dir), 1)[1].lstrip(os.path.sep)
+                        video_subfolder = ""
                     video_item_for_ui = {
-                        "filename": (dest_name if save_video else dest_path.replace("temp/", "", 1)),
+                        "filename": filename_for_ui,
                         "subfolder": video_subfolder,  # This should be "" if not saved, or "veo" if saved
                         "type": (
                             "output" if save_video else "temp"

--- a/google_genmedia/helper_nodes.py
+++ b/google_genmedia/helper_nodes.py
@@ -161,7 +161,8 @@ class VeoVideoSaveAndPreview:
         self, video_paths, autoplay, mute, loop, save_video, save_video_file_prefix
     ):
         try:
-            dest_dir = os.path.join("output", "veo")
+            import folder_paths
+            dest_dir = os.path.join(folder_paths.get_output_directory(), "veo")
             os.makedirs(dest_dir, exist_ok=True)
 
             # Setting preview dir to temp as the veo nodes save the video there
@@ -243,7 +244,7 @@ class VeoVideoSaveAndPreview:
                             .lstrip(os.path.sep),
                         )
                     video_item_for_ui = {
-                        "filename": dest_path,
+                        "filename": (dest_name if save_video else dest_path.replace("temp/", "", 1)),
                         "subfolder": video_subfolder,  # This should be "" if not saved, or "veo" if saved
                         "type": (
                             "output" if save_video else "temp"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-google-genmedia-custom-nodes"
 description = "A suite of experimental custom nodes that allows access to Google's 1P models like Veo, Nano Banana, Gemini, Virtual-try-on, Lyria"
-version = "7.0.0"
+version = "8.0.0"
 license = {file = "LICENSE"} 
 
 dependencies = ["google-api-core==2.24.2", "google-cloud-aiplatform==1.111.0", "google-cloud-storage==2.19.0", "google-genai==1.46.0", "google-generativeai==0.8.5", "moviepy==2.2.1", "opencv-python-headless==4.11.0.86"]


### PR DESCRIPTION
## Description
This PR refactors the `VeoVideoSaveAndPreview` class to use ComfyUI's `folder_paths` utilities instead of hardcoded paths for output and temporary directories.

## Changes
- Import `folder_paths` module from ComfyUI
- Replace hardcoded `"output"` path with `folder_paths.get_output_directory()`
- Replace hardcoded `"temp"` path with `folder_paths.get_temp_directory()`
- Simplify and improve path normalization logic for temporary file paths
- Improve code maintainability and compatibility with different ComfyUI configurations

## Benefits
- Better compatibility with custom ComfyUI configurations
- Code is more maintainable and follows ComfyUI best practices
- Cleaner and simpler path handling logic